### PR TITLE
chore: add Dependabot + CI + auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint PHP files
+        run: find . -name '*.php' -print0 | xargs -0 -n1 php -l

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

- `.github/dependabot.yml` — weekly Dependabot updates for the `github-actions` ecosystem (no `composer.json` found, so composer ecosystem not added)
- `.github/workflows/ci.yml` — CI workflow with a `test` job that runs `php -l` lint across all PHP files
- `.github/workflows/dependabot-auto-merge.yml` — auto-merges Dependabot PRs once CI passes
- Branch protection on `master` now requires the `test` status check
- Repo auto-merge setting enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)